### PR TITLE
gitignore for Mac VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .settings
 .project
 .classpath
+.DS_Store
+.vscode/
 **/Icon*
 target
 ignite

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
 #      - 10302:10300
 #      - 10802:10800
   cccc:
-    image: gridgain/cloud-connector:2025-02-14
+    image: gridgain/cloud-connector:2025-05-12
     volumes:
       - ./src/main/resources/controlcenter.conf:/opt/gridgain-cloud-connector/application.properties
 


### PR DESCRIPTION
Update Control Center Cloud Connector image tag version.
Add .gitignores for VSCode and Mac junk